### PR TITLE
feat(table): Add possibility to configure table selection in a way that master checkbox selects all rows across all pages

### DIFF
--- a/apps/demos/src/app-routing.module.ts
+++ b/apps/demos/src/app-routing.module.ts
@@ -339,6 +339,7 @@ import {
   DtExampleDatepickerDark,
   DtExampleDatepickerDefault,
   DtExampleCustomAddFormTag,
+  DtExampleSelectionSelectAllTable,
 } from '@dynatrace/barista-examples';
 
 // The Routing Module replaces the routing configuration in the root or feature module.
@@ -1216,6 +1217,10 @@ const ROUTES: Routes = [
     component: DtExampleSelectCustomValueTemplate,
   },
   { path: 'tag-custom-add-form-example', component: DtExampleCustomAddFormTag },
+  {
+    path: 'table-selection-select-all-example',
+    component: DtExampleSelectionSelectAllTable,
+  },
 ];
 
 @NgModule({

--- a/apps/demos/src/nav-items.ts
+++ b/apps/demos/src/nav-items.ts
@@ -1409,6 +1409,10 @@ export const DT_DEMOS_EXAMPLE_NAV_ITEMS = [
         route: '/table-selection',
       },
       {
+        name: 'table-selection-select-all-example',
+        route: '/table-selection-select-all-example',
+      },
+      {
         name: 'table-observable-example',
         route: '/table-observable-example',
       },

--- a/libs/barista-components/table/src/selection/selection.ts
+++ b/libs/barista-components/table/src/selection/selection.ts
@@ -36,6 +36,13 @@ export interface DtTableSelectionConfig {
    * By default there is no limit
    */
   selectionLimit?: number;
+
+  /**
+   * When set to true and data source is of type DtTableDataSource, master checkbox
+   * selects rows across all pages (respecting selectionLimit if specified).
+   * By default, master checkbox selection is limited to current page.
+   */
+  globalSelection?: boolean;
 }
 
 /** Injectiontoken used to the DtTableSelection configuration */

--- a/libs/barista-components/table/src/selection/selection.ts
+++ b/libs/barista-components/table/src/selection/selection.ts
@@ -38,9 +38,9 @@ export interface DtTableSelectionConfig {
   selectionLimit?: number;
 
   /**
-   * When set to true and data source is of type DtTableDataSource, master checkbox
+   * When set to true and data source is of type DtTableDataSource, global checkbox
    * selects rows across all pages (respecting selectionLimit if specified).
-   * By default, master checkbox selection is limited to current page.
+   * By default, global checkbox selection is limited to current page.
    */
   globalSelection?: boolean;
 }

--- a/libs/examples/src/index.ts
+++ b/libs/examples/src/index.ts
@@ -348,6 +348,7 @@ import { DtExampleTreeTableProblemIndicator } from './tree-table/tree-table-prob
 import { DtExampleTreeTableSimple } from './tree-table/tree-table-simple-example/tree-table-simple-example';
 import { DtExampleCustomAddFormTag } from '././tag/tag-custom-add-form-example/tag-custom-add-form-example';
 import { DtExampleStackedSeriesChartHeatField } from '././stacked-series-chart/stacked-series-chart-heat-field-example/stacked-series-chart-heat-field-example';
+import { DtExampleSelectionSelectAllTable } from '././table/table-selection-select-all-example/table-selection-select-all-example';
 export { DtAlertExamplesModule } from './alert/alert-examples.module';
 export { DtAutocompleteExamplesModule } from './autocomplete/autocomplete-examples.module';
 export { DtBarIndicatorExamplesModule } from './bar-indicator/bar-indicator-examples.module';
@@ -737,6 +738,7 @@ export {
   DtExampleDatepickerDark,
   DtExampleDatepickerDefault,
   DtExampleCustomAddFormTag,
+  DtExampleSelectionSelectAllTable,
 };
 
 export const EXAMPLES_MAP = new Map<string, Type<unknown>>([
@@ -1135,4 +1137,5 @@ export const EXAMPLES_MAP = new Map<string, Type<unknown>>([
   ['DtExampleTreeTableProblemIndicator', DtExampleTreeTableProblemIndicator],
   ['DtExampleTreeTableSimple', DtExampleTreeTableSimple],
   ['DtExampleCustomAddFormTag', DtExampleCustomAddFormTag],
+  ['DtExampleSelectionSelectAllTable', DtExampleSelectionSelectAllTable],
 ]);

--- a/libs/examples/src/table/index.ts
+++ b/libs/examples/src/table/index.ts
@@ -44,3 +44,4 @@ export * from './table-sorting-example/table-sorting-example';
 export * from './table-sorting-mixed-columns-example/table-sorting-mixed-columns-example';
 export * from './table-sticky-header-example/table-sticky-header-example';
 export * from './table-with-info-group-cell-example/table-with-info-group-cell-example';
+export * from './table-selection-select-all-example/table-selection-select-all-example';

--- a/libs/examples/src/table/table-examples.module.ts
+++ b/libs/examples/src/table/table-examples.module.ts
@@ -59,7 +59,7 @@ import { DtExampleTableStickyHeader } from './table-sticky-header-example/table-
 import { DtExampleTableWithInfoGroupCell } from './table-with-info-group-cell-example/table-with-info-group-cell-example';
 import { DragDropModule } from '@angular/cdk/drag-drop';
 import { FormsModule } from '@angular/forms';
-
+import { DtExampleSelectionSelectAllTable } from './table-selection-select-all-example/table-selection-select-all-example';
 @NgModule({
   imports: [
     CommonModule,
@@ -108,6 +108,7 @@ import { FormsModule } from '@angular/forms';
     DtExampleTableSortingMixedColumns,
     DtExampleTableStickyHeader,
     DtExampleTableWithInfoGroupCell,
+    DtExampleSelectionSelectAllTable,
   ],
 })
 export class DtExamplesTableModule {}

--- a/libs/examples/src/table/table-selection-select-all-example/table-selection-select-all-example.html
+++ b/libs/examples/src/table/table-selection-select-all-example/table-selection-select-all-example.html
@@ -1,0 +1,26 @@
+<dt-table
+  [dataSource]="dataSource"
+  dtSort
+  dtTableSelection
+  [dtTableIsRowDisabled]="isDisabled"
+>
+  <ng-container dtColumnDef="checkbox">
+    <dt-table-header-selector
+      *dtHeaderCellDef
+      aria-label="Toggle all hosts"
+    ></dt-table-header-selector>
+    <dt-table-row-selector
+      *dtCellDef="let row"
+      [row]="row"
+      [aria-label]="'Toggle ' + row.host"
+    ></dt-table-row-selector>
+  </ng-container>
+  <dt-simple-text-column name="host" label="Host"></dt-simple-text-column>
+  <dt-simple-number-column name="cpu" label="CPU"></dt-simple-number-column>
+  <dt-header-row *dtHeaderRowDef="['checkbox', 'host', 'cpu']"></dt-header-row>
+  <dt-row *dtRowDef="let row; columns: ['checkbox', 'host', 'cpu']"></dt-row>
+</dt-table>
+
+<dt-pagination></dt-pagination>
+
+Current selection: {{ getCurrentSelection() }}

--- a/libs/examples/src/table/table-selection-select-all-example/table-selection-select-all-example.scss
+++ b/libs/examples/src/table/table-selection-select-all-example/table-selection-select-all-example.scss
@@ -1,0 +1,3 @@
+.dt-selection-panel {
+  margin-top: 20px;
+}

--- a/libs/examples/src/table/table-selection-select-all-example/table-selection-select-all-example.ts
+++ b/libs/examples/src/table/table-selection-select-all-example/table-selection-select-all-example.ts
@@ -1,0 +1,117 @@
+/**
+ * @license
+ * Copyright 2022 Dynatrace LLC
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { AfterViewInit, Component, ViewChild } from '@angular/core';
+import { DtPagination } from '@dynatrace/barista-components/pagination';
+import {
+  DT_TABLE_SELECTION_CONFIG,
+  DtSort,
+  DtTableDataSource,
+  DtTableSelection,
+} from '@dynatrace/barista-components/table';
+import { isNil } from 'lodash-es';
+
+interface Row {
+  host: string;
+  cpu: number;
+}
+
+@Component({
+  selector: 'dt-example-selection-select-all-table',
+  templateUrl: './table-selection-select-all-example.html',
+  styleUrls: ['./table-selection-select-all-example.scss'],
+  providers: [
+    {
+      provide: DT_TABLE_SELECTION_CONFIG,
+      useValue: { globalSelection: true },
+    },
+  ],
+})
+export class DtExampleSelectionSelectAllTable implements AfterViewInit {
+  data: Row[] = [
+    {
+      host: 'et-demo-2-win4',
+      cpu: 30,
+    },
+    {
+      host: 'et-demo-2-win3',
+      cpu: 26,
+    },
+    {
+      host: 'docker-host2',
+      cpu: 25.4,
+    },
+    {
+      host: 'et-demo-2-win1',
+      cpu: 23,
+    },
+    {
+      host: 'et-demo-2-win5',
+      cpu: 23,
+    },
+    {
+      host: 'et-demo-2-win6',
+      cpu: 23,
+    },
+    {
+      host: 'et-demo-2-win7',
+      cpu: 23,
+    },
+    {
+      host: 'et-demo-2-win8',
+      cpu: 23,
+    },
+    {
+      host: 'my host (disabled)',
+      cpu: 13,
+    },
+  ];
+
+  // Get the viewChild to pass the sorter reference to the datasource.
+  @ViewChild(DtSort, { read: DtSort, static: true }) sortable: DtSort;
+  @ViewChild(DtTableSelection, { read: DtTableSelection, static: true })
+  selection: DtTableSelection<Row>;
+  @ViewChild(DtPagination, { static: true }) pagination: DtPagination;
+
+  // Initialize the table's data source
+  dataSource: DtTableDataSource<Row>;
+
+  constructor() {
+    this.dataSource = new DtTableDataSource(this.data);
+  }
+
+  ngAfterViewInit(): void {
+    // Set the dtSort reference on the dataSource, so it can react to sorting.
+    this.dataSource.sort = this.sortable;
+    this.dataSource.pagination = this.pagination;
+    this.dataSource.pageSize = 5;
+  }
+
+  getCurrentSelection(): string {
+    return this.selection.selected.map((data: Row) => data.host).join(', ');
+  }
+
+  isDisabled(entry: { host: string; cpu: number }): boolean {
+    return entry.host.endsWith('(disabled)');
+  }
+
+  getAriaLabel(value: Row | undefined): string {
+    if (isNil(value)) {
+      return 'Select hosts';
+    }
+    return 'Select ' + value!.host;
+  }
+}


### PR DESCRIPTION
### <strong>Pull Request</strong>

In the case of tables with pagination, the global checkbox selects all rows in the currently displayed page (with respect to selection limit and selection enabled / disabled for a given row). 
Now, it is possible to configure table selection so that master checkbox select all rows across all pages.

`providers: [
    {
      provide: DT_TABLE_SELECTION_CONFIG,
      useValue: { globalSelection: true },
    },
  ],`

#### Type of PR

Feature

#### Checklist

- [x] I have read the CONTRIBUTING doc and I follow the PR guidelines
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
